### PR TITLE
Implement ChangingOrder search order

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BranchAndPrune"
 uuid = "d3bc4f2e-91e6-11e9-365e-cd067da536ce"
 authors = ["Benoît Richard <kolaru@hotmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/BranchAndPrune.jl
+++ b/src/BranchAndPrune.jl
@@ -2,12 +2,14 @@ module BranchAndPrune
 
 using AbstractTrees
 
-export BranchAndPruneSearch, bpsearch
+include("tree.jl")
+export regions, finished_regions, unfinished_regions
+
+include("search_order.jl")
 export SearchOrder, BreadthFirst, DepthFirst, ChangingOrder
 export push!, pop!, set_next!
 
-include("tree.jl")
-include("search_order.jl")
 include("search.jl")
+export BranchAndPruneSearch, SearchState, BranchAndPruneResult, bpsearch
 
 end  # module

--- a/src/BranchAndPrune.jl
+++ b/src/BranchAndPrune.jl
@@ -4,6 +4,7 @@ using AbstractTrees
 
 export BranchAndPruneSearch, bpsearch
 export SearchOrder, BreadthFirst, DepthFirst, ChangingOrder
+export push!, pop!, set_next!
 
 include("tree.jl")
 include("search_order.jl")

--- a/src/BranchAndPrune.jl
+++ b/src/BranchAndPrune.jl
@@ -3,7 +3,7 @@ module BranchAndPrune
 using AbstractTrees
 
 export BranchAndPruneSearch, bpsearch
-export SearchOrder, BreadthFirst, DepthFirst
+export SearchOrder, BreadthFirst, DepthFirst, ChangingOrder
 
 include("tree.jl")
 include("search_order.jl")

--- a/src/search.jl
+++ b/src/search.jl
@@ -70,6 +70,32 @@ function SearchState(S, initial_region::REGION) where REGION
     return SearchState(S(root), root, 1)
 end
 
+regions(state::SearchState) = regions(state.tree)
+unfinished_regions(state::SearchState) = [leaf.region for leaf in state.search_order.working_leaves]
+finished_regions(state::SearchState) = finished_regions(state.tree)
+
+function Base.show(io::IO, state::SearchState{S, REGION}) where {S, REGION}
+    println(io, """
+    SearchState{$S, $REGION}
+      iteration: $(state.iteration)
+      $(length(unfinished_regions(state.tree))) regions being processed""")
+    for (i, region) in enumerate(unfinished_regions(state))
+        println(io, "    $region")
+
+        if i == 10
+            println("        ⋮")
+        end
+    end
+
+    println(io, "  $(length(finished_regions(state.tree))) finalized regions")
+    for (i, region) in enumerate(finished_regions(state))
+        println(io, "    $region")
+        if i == 10
+            println("        ⋮")
+        end
+    end
+end
+
 function Base.iterate(
         bp::BranchAndPruneSearch{S},
         state = SearchState(S, bp.initial_region)) where S
@@ -137,17 +163,14 @@ function BranchAndPruneResult(
         search_order,
         initial_region::REGION,
         tree::BPNode{REGION}) where REGION
-    
-    final_regions = REGION[leaf.region for leaf in Leaves(tree) if leaf.status == :final]
-    unfinished_regions = REGION[leaf.region for leaf in Leaves(tree) if leaf.status == :working]
 
     return BranchAndPruneResult(
         search_order,
         initial_region,
         tree,
-        final_regions,
-        unfinished_regions,
-        isempty(unfinished_regions)
+        finished_regions(tree),
+        unfinished_regions(tree),
+        isempty(unfinished_regions(tree))
     )
 end
 

--- a/src/search_order.jl
+++ b/src/search_order.jl
@@ -27,6 +27,13 @@ end
 
 BreadthFirst(root::BPNode) = BreadthFirst([root])
 
+mutable struct ChangingOrder{REGION} <: SearchOrder
+    working_leaves::Vector{BPNode{REGION}}
+    next::Int 
+end
+
+ChangingOrder(root::BPNode) = ChangingOrder([root], 1)
+
 """
     pop!(::SearchOrder)
 
@@ -40,6 +47,13 @@ Must be define for custom search orders.
 """
 Base.pop!(so::BreadthFirst) = isempty(so.working_leaves) ? nothing : popfirst!(so.working_leaves)
 Base.pop!(so::DepthFirst) = isempty(so.working_leaves) ? nothing : pop!(so.working_leaves)
+function Base.pop!(so::ChangingOrder)
+    isempty(so.working_leaves) && return nothing
+    next = so.working_leaves[so.next]
+    deleteat!(so.working_leaves, so.next)
+    so.next = 1
+    return next
+end 
 
 """
     push!(::SearchOrder, leaf::BPNode)
@@ -50,4 +64,4 @@ Can modify the internal state of the SearchOrder.
 
 Must be define for custom search orders.
 """
-Base.push!(so::Union{DepthFirst, BreadthFirst}, leaf::BPNode) = push!(so.working_leaves, leaf)
+Base.push!(so::Union{DepthFirst, BreadthFirst, ChangingOrder}, leaf::BPNode) = push!(so.working_leaves, leaf)

--- a/src/search_order.jl
+++ b/src/search_order.jl
@@ -33,6 +33,7 @@ mutable struct ChangingOrder{REGION} <: SearchOrder
 end
 
 ChangingOrder(root::BPNode) = ChangingOrder([root], 1)
+set_next!(so::ChangingOrder, i::Int) = (so.next = i)
 
 """
     pop!(::SearchOrder)

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -45,7 +45,6 @@ function Base.setindex!(node::BPNode, child::BPNode, side::Symbol)
     throw(ArgumentError("BPNOde can only be indexed with :left or :right"))
 end
 
-
 """
     prune!(node::BPNOde ; squash = true)
 
@@ -93,6 +92,10 @@ function squash_node!(node::BPNode)
         child.parent = parent
     end
 end
+
+regions(tree::BPNode) = vcat(unfinished_regions(tree), finished_regions(tree))
+finished_regions(tree::BPNode{REGION}) where REGION = REGION[leaf.region for leaf in Leaves(tree) if leaf.status == :final]
+unfinished_regions(tree::BPNode{REGION}) where REGION = REGION[leaf.region for leaf in Leaves(tree) if leaf.status == :working]
 
 # AbstractTree.jl API
 function AbstractTrees.children(node::BPNode{REGION}) where REGION

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -27,7 +27,12 @@ function BPNode(status, region, parent, side)
     return node
 end
 
-Base.show(io::IO, ::MIME"text/plain", tree::BPNode) = print_tree(io, tree)
+function Base.show(io::IO, node::BPNode)
+    print(io, "BPNode($(node.status), $(node.region))")
+end
+
+Base.show(io::IO, ::MIME"text/plain", node::BPNode) = print_tree(io, node)
+
 function Base.getindex(node::BPNode, side::Symbol)
     side == :left && return node.left_child
     side == :right && return node.right_child

--- a/test/search_order.jl
+++ b/test/search_order.jl
@@ -29,4 +29,10 @@
     @test pop!(breadth_first) == n4
     @test pop!(breadth_first) == n3
     @test isnothing(pop!(breadth_first))
+
+    changing = ChangingOrder(n5)
+    push!(changing, n4)
+    push!(changing, n3)
+    set_next!(changing, 2)
+    @test pop!(changing) == n4
 end


### PR DESCRIPTION
The new ChangingOrder search order allows to manually set the next region to be processed using the `set_next!` function.

If `set_next!` is not used, it behave like a BreadthFirstSearch.